### PR TITLE
Add `source $HOME/.profile` to bash_profile

### DIFF
--- a/termux.sh
+++ b/termux.sh
@@ -244,6 +244,10 @@ function finish() {
 		touch "$HOME/.hushlogin"
 	fi
 
+	if ! grep -q "source ~/.profile" $HOME/.bash_profile >/dev/null 2>&1; then
+		echo -e "\n# Include ~/.profile created by onlurking/termux script\nif [ -f ~/.profile ]; then\n  source ~/.profile\nfi" >> $HOME/.bash_profile
+	fi
+
 	if ask "\\e[32m[ finished ]\\e[m close termux to apply settings?" Y; then
 		pkill termux
 	else

--- a/termux.sh
+++ b/termux.sh
@@ -245,7 +245,7 @@ function finish() {
 	fi
 
 	if ! grep -q "source ~/.profile" $HOME/.bash_profile >/dev/null 2>&1; then
-		echo -e "\n# Include ~/.profile created by onlurking/termux script\nif [ -f ~/.profile ]; then\n  source ~/.profile\nfi" >> $HOME/.bash_profile
+		echo -e "\nif [ -f ~/.profile ]; then\n  source ~/.profile\nfi" >> $HOME/.bash_profile
 	fi
 
 	if ask "\\e[32m[ finished ]\\e[m close termux to apply settings?" Y; then


### PR DESCRIPTION
Hi @onlurking !

I have another PR for you (the last one at least for now 🙃)

This PR adds `source $HOME/.profile` to the file `.bash_profile`, this will allows that Elixir, Rebar, Postgres, Golang and all others who use `$HOME/.profile` have theirs bins added to the PATH even if the user has the default *bash* that cames with Termux, rather than *zsh*.

- If the file `.bash_profile` doesn't exists... it will create it and send the `stderr` to `/dev/null`
- If the file `.bash_profile` exists... it will left intact the current content of the file and append the `source $HOME/.profile` at the bottom.
- If the users runs again the installer (i.e. `curl -fsSL https://git.io/termux | bash -s -- ..`) it will not duplicate the `source $HOME/.profile` chunk on `.bash_profile`.
- It will add a validation on `.bash_profile` to only import `$HOME/.profile` if exists (in case it get deleted in the future for some reason).
- It will add a comment referencing the repo (e.g. *# Include ~/.profile created by onlurking/termux script*)

I made some tests before and everything seems to work fine, I hope this can help and if you see anything that needs to be changed... let me know so I can fix it.

Regards!
✌️ 

Test (Part 1):

![screenshot 2018-05-21 at 07 38 58](https://user-images.githubusercontent.com/24572406/40310499-45adcb8a-5cca-11e8-9356-218770ceaf08.png)

Test (Part 2):

![screenshot 2018-05-21 at 07 39 50](https://user-images.githubusercontent.com/24572406/40310520-51d80c5e-5cca-11e8-889e-c253bde8d230.png)

cc // @paunix